### PR TITLE
Stowrs error reporting and export adapter changes (fixed cla)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ containers in `dicom_adapter.yaml`. Modify the flags for your use case.
             - "--oauth_scopes=https://www.googleapis.com/auth/pubsub"
 ```
 
+The peer_dicomweb_addr and peer_dicomweb_stow_path parameters have been deprecated, please use the peer_dicomweb_address parameter instead.
+
 To deploy the configuration to GKE cluster, execute the following:
 
 ```shell

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,5 @@
 steps:
-- name: 'gradle:5.4.1-jdk8'
+- name: 'gradle:5.6-jdk11'
   args:
   - gradle
   - build

--- a/dicom_util/build.gradle
+++ b/dicom_util/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'java'
 
 buildDir = '/tmp/gradle_build/dicom_adapter/dicom_util'
 
-sourceCompatibility = 1.8
+sourceCompatibility = 1.11
 version = '0.0.1'
 
 compileJava {
@@ -41,6 +41,11 @@ dependencies {
     compile "org.junit.jupiter:junit-jupiter-engine:5.0.0"
     compile "org.dcm4che:dcm4che-core:3.3.8"
     compile "org.dcm4che:dcm4che-net:3.3.8"
+
+    compile 'com.google.auth:google-auth-library-oauth2-http:0.9.0'
+    compile group: 'org.eclipse.jetty.http2', name: 'http2-client', version: '9.4.20.v20190813'
+    compile group: 'org.eclipse.jetty', name: 'jetty-alpn-java-client', version: '9.4.20.v20190813'
+
     compile group: 'org.slf4j', name: 'slf4j-log4j12', version: '1.7.25'
     compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.8.2'
     compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.8.2'

--- a/dicom_util/src/main/java/com/google/cloud/healthcare/DicomWebClient.java
+++ b/dicom_util/src/main/java/com/google/cloud/healthcare/DicomWebClient.java
@@ -50,7 +50,7 @@ public class DicomWebClient implements IDicomWebClient {
       HttpRequestFactory requestFactory,
       @Annotations.DicomwebAddr String serviceUrlPrefix) {
     this.requestFactory = requestFactory;
-    this.serviceUrlPrefix = Util.trim(serviceUrlPrefix);
+    this.serviceUrlPrefix = StringUtil.trim(serviceUrlPrefix);
   }
 
   /**
@@ -60,7 +60,7 @@ public class DicomWebClient implements IDicomWebClient {
     try {
       HttpRequest httpRequest =
           requestFactory.buildGetRequest(new GenericUrl(serviceUrlPrefix + "/"
-              + Util.trim(path)));
+              + StringUtil.trim(path)));
       HttpResponse httpResponse = httpRequest.execute();
 
       return new MultipartInput(httpResponse.getContent(), httpResponse.getContentType());
@@ -80,7 +80,7 @@ public class DicomWebClient implements IDicomWebClient {
     try {
       HttpRequest httpRequest =
           requestFactory.buildGetRequest(new GenericUrl(serviceUrlPrefix + "/"
-              + Util.trim(path)));
+              + StringUtil.trim(path)));
       HttpResponse httpResponse = httpRequest.execute();
 
       // dcm4che server can return 204 responses.
@@ -106,7 +106,7 @@ public class DicomWebClient implements IDicomWebClient {
    * @param in The DICOM input stream.
    */
   public void stowRs(String path, InputStream in) throws IDicomWebClient.DicomWebException {
-    GenericUrl url = new GenericUrl(serviceUrlPrefix + "/" + Util.trim(path));
+    GenericUrl url = new GenericUrl(serviceUrlPrefix + "/" + StringUtil.trim(path));
 
     // DICOM "Type" parameter:
     // http://dicom.nema.org/medical/dicom/current/output/html/part18.html#sect_6.6.1.1.1

--- a/dicom_util/src/main/java/com/google/cloud/healthcare/DicomWebClient.java
+++ b/dicom_util/src/main/java/com/google/cloud/healthcare/DicomWebClient.java
@@ -24,7 +24,6 @@ import com.google.api.client.http.HttpResponseException;
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.api.client.http.InputStreamContent;
 import com.google.api.client.http.MultipartContent;
-import com.google.common.base.CharMatcher;
 import com.google.common.io.CharStreams;
 import java.io.IOException;
 import java.io.InputStream;
@@ -51,7 +50,7 @@ public class DicomWebClient implements IDicomWebClient {
       HttpRequestFactory requestFactory,
       @Annotations.DicomwebAddr String serviceUrlPrefix) {
     this.requestFactory = requestFactory;
-    this.serviceUrlPrefix = trim(serviceUrlPrefix);
+    this.serviceUrlPrefix = Util.trim(serviceUrlPrefix);
   }
 
   /**
@@ -61,14 +60,14 @@ public class DicomWebClient implements IDicomWebClient {
     try {
       HttpRequest httpRequest =
           requestFactory.buildGetRequest(new GenericUrl(serviceUrlPrefix + "/"
-              + trim(path)));
+              + Util.trim(path)));
       HttpResponse httpResponse = httpRequest.execute();
 
       return new MultipartInput(httpResponse.getContent(), httpResponse.getContentType());
     } catch (HttpResponseException e) {
-      throw httpToDicomWebException(e,
+      throw new DicomWebException(
           String.format("WadoRs: %d, %s", e.getStatusCode(), e.getStatusMessage()),
-          Status.ProcessingFailure);
+          e, e.getStatusCode(), Status.ProcessingFailure);
     } catch (IOException | IllegalArgumentException e) {
       throw new IDicomWebClient.DicomWebException(e);
     }
@@ -81,7 +80,7 @@ public class DicomWebClient implements IDicomWebClient {
     try {
       HttpRequest httpRequest =
           requestFactory.buildGetRequest(new GenericUrl(serviceUrlPrefix + "/"
-              + trim(path)));
+              + Util.trim(path)));
       HttpResponse httpResponse = httpRequest.execute();
 
       // dcm4che server can return 204 responses.
@@ -92,9 +91,9 @@ public class DicomWebClient implements IDicomWebClient {
           CharStreams
               .toString(new InputStreamReader(httpResponse.getContent(), StandardCharsets.UTF_8)));
     } catch (HttpResponseException e) {
-      throw httpToDicomWebException(e,
+      throw new DicomWebException(
           String.format("QidoRs: %d, %s", e.getStatusCode(), e.getStatusMessage()),
-          Status.UnableToCalculateNumberOfMatches);
+          e, e.getStatusCode(), Status.UnableToCalculateNumberOfMatches);
     } catch (IOException | IllegalArgumentException e) {
       throw new IDicomWebClient.DicomWebException(e);
     }
@@ -107,7 +106,7 @@ public class DicomWebClient implements IDicomWebClient {
    * @param in The DICOM input stream.
    */
   public void stowRs(String path, InputStream in) throws IDicomWebClient.DicomWebException {
-    GenericUrl url = new GenericUrl(serviceUrlPrefix + "/" + trim(path));
+    GenericUrl url = new GenericUrl(serviceUrlPrefix + "/" + Util.trim(path));
 
     // DICOM "Type" parameter:
     // http://dicom.nema.org/medical/dicom/current/output/html/part18.html#sect_6.6.1.1.1
@@ -121,31 +120,11 @@ public class DicomWebClient implements IDicomWebClient {
       HttpRequest httpRequest = requestFactory.buildPostRequest(url, content);
       httpRequest.execute();
     } catch (HttpResponseException e) {
-      throw httpToDicomWebException(e,
+      throw new DicomWebException(
           String.format("StowRs: %d, %s", e.getStatusCode(), e.getStatusMessage()),
-          Status.ProcessingFailure);
+          e, e.getStatusCode(), Status.ProcessingFailure);
     } catch (IOException e) {
       throw new IDicomWebClient.DicomWebException(e);
     }
-  }
-
-  private IDicomWebClient.DicomWebException httpToDicomWebException(
-      HttpResponseException httpException,
-      String message,
-      int defaultStatus) {
-    int dicomStatus = defaultStatus;
-    switch (httpException.getStatusCode()) {
-      case HttpStatusCodes.STATUS_CODE_SERVICE_UNAVAILABLE:
-        dicomStatus = Status.OutOfResources;
-        break;
-      case HttpStatusCodes.STATUS_CODE_UNAUTHORIZED:
-        dicomStatus = Status.NotAuthorized;
-        break;
-    }
-    return new IDicomWebClient.DicomWebException(message, httpException, dicomStatus);
-  }
-
-  private String trim(String value) {
-    return CharMatcher.is('/').trimFrom(value);
   }
 }

--- a/dicom_util/src/main/java/com/google/cloud/healthcare/DicomWebClientJetty.java
+++ b/dicom_util/src/main/java/com/google/cloud/healthcare/DicomWebClientJetty.java
@@ -43,7 +43,7 @@ public class DicomWebClientJetty implements IDicomWebClient {
       OAuth2Credentials credentials,
       String serviceUrlPrefix) {
     this.credentials = credentials;
-    this.serviceUrlPrefix = Util.trim(serviceUrlPrefix);
+    this.serviceUrlPrefix = StringUtil.trim(serviceUrlPrefix);
   }
 
   @Override
@@ -64,7 +64,7 @@ public class DicomWebClientJetty implements IDicomWebClient {
       client.addBean(sslContextFactory);
       client.start();
 
-      HttpURI uri = new HttpURI(serviceUrlPrefix + "/" + Util.trim(path));
+      HttpURI uri = new HttpURI(serviceUrlPrefix + "/" + StringUtil.trim(path));
 
       FuturePromise<Session> sessionPromise = new FuturePromise<>();
       client.connect(sslContextFactory, new InetSocketAddress(uri.getHost(), CONNECT_PORT),

--- a/dicom_util/src/main/java/com/google/cloud/healthcare/DicomWebClientJetty.java
+++ b/dicom_util/src/main/java/com/google/cloud/healthcare/DicomWebClientJetty.java
@@ -1,0 +1,215 @@
+package com.google.cloud.healthcare;
+
+import com.github.danieln.multipart.MultipartInput;
+import com.google.auth.oauth2.OAuth2Credentials;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.dcm4che3.net.Status;
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpURI;
+import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.http.MetaData;
+import org.eclipse.jetty.http.MetaData.Response;
+import org.eclipse.jetty.http2.api.Session;
+import org.eclipse.jetty.http2.api.Stream;
+import org.eclipse.jetty.http2.api.server.ServerSessionListener;
+import org.eclipse.jetty.http2.client.HTTP2Client;
+import org.eclipse.jetty.http2.frames.DataFrame;
+import org.eclipse.jetty.http2.frames.HeadersFrame;
+import org.eclipse.jetty.http2.frames.ResetFrame;
+import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.FuturePromise;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+public class DicomWebClientJetty implements IDicomWebClient {
+
+  private static final int CONNECT_PORT = 443;
+
+  private final String serviceUrlPrefix;
+  private final OAuth2Credentials credentials;
+
+  public DicomWebClientJetty(
+      OAuth2Credentials credentials,
+      String serviceUrlPrefix) {
+    this.credentials = credentials;
+    this.serviceUrlPrefix = Util.trim(serviceUrlPrefix);
+  }
+
+  @Override
+  public MultipartInput wadoRs(String path) throws DicomWebException {
+    throw new UnsupportedOperationException("Not Implemented, use DicomWebClient");
+  }
+
+  @Override
+  public JSONArray qidoRs(String path) throws DicomWebException {
+    throw new UnsupportedOperationException("Not Implemented, use DicomWebClient");
+  }
+
+  @Override
+  public void stowRs(String path, InputStream in) throws DicomWebException {
+    try {
+      HTTP2Client client = new HTTP2Client();
+      SslContextFactory sslContextFactory = new SslContextFactory.Client();
+      client.addBean(sslContextFactory);
+      client.start();
+
+      HttpURI uri = new HttpURI(serviceUrlPrefix + "/" + Util.trim(path));
+
+      FuturePromise<Session> sessionPromise = new FuturePromise<>();
+      client.connect(sslContextFactory, new InetSocketAddress(uri.getHost(), CONNECT_PORT),
+          new ServerSessionListener.Adapter(), sessionPromise);
+      Session session = sessionPromise.get(5, TimeUnit.SECONDS);
+
+      // Prepare the request
+      HttpFields requestFields = new HttpFields();
+      if (credentials != null) {
+        credentials.getRequestMetadata();
+        requestFields.add(HttpHeader.AUTHORIZATION,
+            "Bearer " + credentials.getAccessToken().getTokenValue());
+      }
+      requestFields.add(HttpHeader.CONTENT_TYPE,
+          "application/dicom");
+      MetaData.Request request = new MetaData.Request("POST", uri, HttpVersion.HTTP_2,
+          requestFields);
+      HeadersFrame headersFrame = new HeadersFrame(request, null, false);
+
+      // Prepare the listener to receive the HTTP response frames.
+      final StringBuilder resultBuilder = new StringBuilder();
+      final CompletableFuture<Integer> responseCodeFuture = new CompletableFuture<>();
+      final CompletableFuture<Boolean> doneFuture = new CompletableFuture<>();
+      Stream.Listener responseListener = new Stream.Listener.Adapter() {
+        @Override
+        public void onReset(Stream stream, ResetFrame frame) {
+          doneFuture.complete(false);
+        }
+
+        @Override
+        public void onHeaders(Stream stream, HeadersFrame frame) {
+          if (frame.getMetaData() instanceof Response) {
+            responseCodeFuture.complete(((Response) frame.getMetaData()).getStatus());
+          }
+        }
+
+        @Override
+        public void onData(Stream stream, DataFrame frame, Callback callback) {
+          byte[] bytes = new byte[frame.getData().remaining()];
+          frame.getData().get(bytes);
+          resultBuilder.append(new String(bytes, StandardCharsets.UTF_8));
+
+          if (frame.isEndStream()) {
+            doneFuture.complete(true);
+          }
+
+          callback.succeeded();
+        }
+      };
+
+      FuturePromise<Stream> streamPromise = new FuturePromise<>();
+      session.newStream(headersFrame, streamPromise, responseListener);
+      Stream stream = streamPromise.get();
+
+      DataStream dataStream = new DataStream(stream, in);
+      try {
+        dataStream.send();
+      } catch (IOException e) {
+        if (!doneFuture.isDone()) {
+          throw e;
+        }
+      }
+
+      doneFuture.get();
+      client.stop();
+
+      int httpStatus = responseCodeFuture.get();
+      if (httpStatus != HttpStatus.OK_200) {
+        JSONObject responseJson = new JSONObject(resultBuilder.toString());
+        throw new DicomWebException("Http_" + responseCodeFuture.get()
+            + ", " + responseJson.getJSONObject("error").getString("status")
+            + ", " + responseJson.getJSONObject("error").getString("message"),
+            httpStatus, Status.ProcessingFailure);
+      }
+    } catch (Exception e) {
+      if (e instanceof DicomWebException) {
+        throw (DicomWebException) e;
+      }
+      throw new DicomWebException(e);
+    }
+  }
+
+  private static class DataStream {
+
+    private static final int BUFFER_SIZE = 8192;
+
+    private final byte[] buffer = new byte[BUFFER_SIZE];
+    private final InputStream in;
+    private final Stream stream;
+
+    private boolean endStream = false;
+
+    public DataStream(Stream http2stream, InputStream inputStream) {
+      this.stream = http2stream;
+      this.in = inputStream;
+    }
+
+    public boolean hasNextFrame() {
+      return !endStream;
+    }
+
+    public DataFrame nextFrame() throws IOException {
+      int read = in.read(buffer);
+      if (read == -1) {
+        endStream = true;
+        return new DataFrame(stream.getId(),
+            ByteBuffer.wrap(buffer, 0, 0), true);
+      } else {
+        return new DataFrame(stream.getId(),
+            ByteBuffer.wrap(buffer, 0, read), false);
+      }
+    }
+
+    public void send() throws IOException {
+      CheckerCallback callback = new CheckerCallback();
+      while (hasNextFrame()) {
+        stream.data(nextFrame(), callback);
+        callback.checkAndReset();
+      }
+    }
+  }
+
+  private static class CheckerCallback implements Callback {
+
+    private CompletableFuture<Throwable> result = new CompletableFuture<Throwable>();
+
+    @Override
+    public void succeeded() {
+      result.complete(null);
+    }
+
+    @Override
+    public void failed(Throwable x) {
+      result.complete(x);
+    }
+
+    public void checkAndReset() throws IOException {
+      try {
+        Throwable x = result.get();
+        result = new CompletableFuture<>();
+        if (x != null) {
+          throw new IOException(x);
+        }
+      } catch (InterruptedException | ExecutionException e) {
+        throw new IOException(e);
+      }
+    }
+  }
+}

--- a/dicom_util/src/main/java/com/google/cloud/healthcare/IDicomWebClient.java
+++ b/dicom_util/src/main/java/com/google/cloud/healthcare/IDicomWebClient.java
@@ -15,6 +15,7 @@
 package com.google.cloud.healthcare;
 
 import com.github.danieln.multipart.MultipartInput;
+import com.google.api.client.http.HttpStatusCodes;
 import java.io.InputStream;
 import org.dcm4che3.data.Attributes;
 import org.dcm4che3.data.Tag;
@@ -52,6 +53,23 @@ public interface IDicomWebClient {
       this.status = status;
     }
 
+    public DicomWebException(
+        String message,
+        int httpStatus,
+        int defaultDicomStatus) {
+      super(message);
+      this.status = httpStatusToDicomStatus(httpStatus, defaultDicomStatus);
+    }
+
+    public DicomWebException(
+        String message,
+        Throwable cause,
+        int httpStatus,
+        int defaultDicomStatus) {
+      super(message, cause);
+      this.status = httpStatusToDicomStatus(httpStatus, defaultDicomStatus);
+    }
+
     public DicomWebException(String message) {
       super(message);
     }
@@ -69,5 +87,17 @@ public interface IDicomWebClient {
       attrs.setString(Tag.ErrorComment, VR.LO, getMessage());
       return attrs;
     }
+
+    private int httpStatusToDicomStatus(int httpStatus, int defaultStatus) {
+      switch (httpStatus) {
+        case HttpStatusCodes.STATUS_CODE_SERVICE_UNAVAILABLE:
+          return Status.OutOfResources;
+        case HttpStatusCodes.STATUS_CODE_UNAUTHORIZED:
+          return Status.NotAuthorized;
+        default:
+          return defaultStatus;
+      }
+    }
+
   }
 }

--- a/dicom_util/src/main/java/com/google/cloud/healthcare/LogUtil.java
+++ b/dicom_util/src/main/java/com/google/cloud/healthcare/LogUtil.java
@@ -35,6 +35,8 @@ public class LogUtil {
         "log4j.appender.console.layout.ConversionPattern", "%-5p %c %x - %m%n");
     // to prevent log spam by stackdriver monitoring
     log4jProperties.setProperty("log4j.logger.io.grpc.netty.shaded.io", "WARN");
+    // very spammy otherwise
+    log4jProperties.setProperty("log4j.logger.org.eclipse.jetty", "WARN");
     PropertyConfigurator.configure(log4jProperties);
   }
 }

--- a/dicom_util/src/main/java/com/google/cloud/healthcare/StringUtil.java
+++ b/dicom_util/src/main/java/com/google/cloud/healthcare/StringUtil.java
@@ -2,7 +2,7 @@ package com.google.cloud.healthcare;
 
 import com.google.common.base.CharMatcher;
 
-public class Util {
+public class StringUtil {
 
   public static String trim(String value) {
     return CharMatcher.is('/').trimFrom(value);

--- a/dicom_util/src/main/java/com/google/cloud/healthcare/Util.java
+++ b/dicom_util/src/main/java/com/google/cloud/healthcare/Util.java
@@ -1,0 +1,10 @@
+package com.google.cloud.healthcare;
+
+import com.google.common.base.CharMatcher;
+
+public class Util {
+
+  public static String trim(String value) {
+    return CharMatcher.is('/').trimFrom(value);
+  }
+}

--- a/export/build.gradle
+++ b/export/build.gradle
@@ -37,7 +37,7 @@ run {
 
 buildDir = '/tmp/gradle_build/dicom_adapter/export'
 
-sourceCompatibility = 1.8
+sourceCompatibility = 1.11
 version = '0.0.1'
 
 compileJava {
@@ -52,7 +52,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.cloud:google-cloud-pubsub:0.32.0-beta'
+    compile 'com.google.cloud:google-cloud-pubsub:1.89.0'
     compile 'com.google.guava:guava:23.6-jre'
     compile "com.beust:jcommander:1.72"
     compile 'com.google.auth:google-auth-library-oauth2-http:0.9.0'

--- a/export/src/main/java/com/google/cloud/healthcare/imaging/dicomadapter/Flags.java
+++ b/export/src/main/java/com/google/cloud/healthcare/imaging/dicomadapter/Flags.java
@@ -39,18 +39,28 @@ public class Flags {
   public static Integer peerDimsePort = 0;
 
   /** Flags for exporting via DicomWeb STOW-RS. */
+  @Deprecated
   @Parameter(
     names = {"--peer_dicomweb_addr"},
-    description = "Address of peer DicomWeb API serving STOW-RS."
+    description = "Address of peer DicomWeb API serving STOW-RS. "
+        + "Deprecated. If peer_dicomweb_address is also specified, it takes precedence."
   )
   public static String peerDicomwebAddr = "";
 
+  @Deprecated
   @Parameter(
     names = {"--peer_dicomweb_stow_path"},
     description =
-        "Path to send StowRS requests for DicomWeb peer. This is appended to the contents of --peer_dicomweb_addr flag."
+        "Path to send StowRS requests for DicomWeb peer. This is appended to the contents of --peer_dicomweb_addr flag. "
+            + "Deprecated. If peer_dicomweb_address is also specified, it takes precedence."
   )
   public static String peerDicomwebStowPath = "";
+
+  @Parameter(
+      names = {"--peer_dicomweb_address"},
+      description = "Address of peer DicomWeb API serving STOW-RS.  Must be a full path up to /dicomWeb if the Cloud Healthcare API is used."
+  )
+  public static String peerDicomwebAddress = "";
 
   @Parameter(
     names = {"--use_gcp_application_default_credentials"},

--- a/export/src/main/java/com/google/cloud/healthcare/imaging/dicomadapter/StowRsSender.java
+++ b/export/src/main/java/com/google/cloud/healthcare/imaging/dicomadapter/StowRsSender.java
@@ -16,7 +16,7 @@ package com.google.cloud.healthcare.imaging.dicomadapter;
 
 import com.github.danieln.multipart.MultipartInput;
 import com.github.danieln.multipart.PartInput;
-import com.google.cloud.healthcare.DicomWebClient;
+import com.google.cloud.healthcare.IDicomWebClient;
 import com.google.cloud.healthcare.imaging.dicomadapter.monitoring.Event;
 import com.google.cloud.healthcare.imaging.dicomadapter.monitoring.MonitoringService;
 import com.google.common.io.CountingInputStream;
@@ -24,13 +24,13 @@ import com.google.pubsub.v1.PubsubMessage;
 
 // StowRsSender sends DICOM to peer using DicomWeb STOW-RS protocol.
 public class StowRsSender implements DicomSender {
-  private DicomWebClient sourceDicomWebClient;
-  private DicomWebClient sinkDicomWebClient;
+  private IDicomWebClient sourceDicomWebClient;
+  private IDicomWebClient sinkDicomWebClient;
   private String sinkDicomWebPath;
 
   StowRsSender(
-      DicomWebClient sourceDicomWebClient,
-      DicomWebClient sinkDicomWebClient,
+      IDicomWebClient sourceDicomWebClient,
+      IDicomWebClient sinkDicomWebClient,
       String sinkDicomWebPath) {
     this.sourceDicomWebClient = sourceDicomWebClient;
     this.sinkDicomWebClient = sinkDicomWebClient;

--- a/import/build.gradle
+++ b/import/build.gradle
@@ -37,7 +37,7 @@ run {
 
 buildDir = '/tmp/gradle_build/dicom_adapter/import'
 
-sourceCompatibility = 1.8
+sourceCompatibility = 1.11
 version = '0.0.1'
 
 compileJava {

--- a/import/src/main/java/com/google/cloud/healthcare/imaging/dicomadapter/ImportAdapter.java
+++ b/import/src/main/java/com/google/cloud/healthcare/imaging/dicomadapter/ImportAdapter.java
@@ -20,6 +20,8 @@ import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.healthcare.DicomWebClient;
+import com.google.cloud.healthcare.DicomWebClientJetty;
+import com.google.cloud.healthcare.IDicomWebClient;
 import com.google.cloud.healthcare.LogUtil;
 import com.google.cloud.healthcare.imaging.dicomadapter.cstoresender.CStoreSenderFactory;
 import com.google.cloud.healthcare.imaging.dicomadapter.monitoring.Event;
@@ -79,14 +81,14 @@ public class ImportAdapter {
       cstoreDicomwebStowPath = flags.dicomwebStowPath;
     }
 
-    DicomWebClient cstoreDicomWebClient =
-        new DicomWebClient(requestFactory, cstoreDicomwebAddr);
+    IDicomWebClient cstoreDicomWebClient =
+        new DicomWebClientJetty(credentials, cstoreDicomwebAddr);
     CStoreService cStoreService =
         new CStoreService(cstoreDicomwebStowPath, cstoreDicomWebClient);
     serviceRegistry.addDicomService(cStoreService);
 
     // Handle C-FIND
-    DicomWebClient dicomWebClient =
+    IDicomWebClient dicomWebClient =
         new DicomWebClient(requestFactory, flags.dicomwebAddress);
     CFindService cFindService = new CFindService(dicomWebClient);
     serviceRegistry.addDicomService(cFindService);

--- a/integration_test/cloudbuild-integration-test.yaml
+++ b/integration_test/cloudbuild-integration-test.yaml
@@ -13,7 +13,7 @@
   - "tags/5.15.1"
   dir: dcm4che
 
-- name: "maven:3.6.1-jdk-8"
+- name: ${_MAVEN_IMAGE}
   id: build-tools
   volumes:
   - name: 'vol1'
@@ -22,7 +22,7 @@
   - bash
   - integration_test/mvn-install-tools.sh
 
-- name: "maven:3.6.1-jdk-8"
+- name: ${_MAVEN_IMAGE}
   id: store-scp
   args:
   - bash
@@ -32,7 +32,7 @@
   - ${_CLOSE_STORE_SCP_PORT}
 
 # run adapter, close when connection established on _CLOSE_ADAPTER_PORT
-- name: 'gradle:5.4.1-jdk8'
+- name: ${_GRADLE_IMAGE}
   id: adapter-main
   args: [ 'bash', '../integration_test/run-adapter-and-wait.sh', '${_VERSION}', '${_PROJECT}', '${_LOCATION}', '${_DATASET}', '${_STORE_NAME}', '${_ADAPTER_PORT}', '${_CLOSE_ADAPTER_PORT}', '${_STORE_SCP_RUN_STEP}', '${_STORE_SCP_PORT}', '${_COMMITMENT_SCU_STEP}', '${_COMMITMENT_SCU_PORT}']
   dir: import
@@ -74,7 +74,7 @@
   waitFor:
   - build-tools
 
-- name: "maven:3.6.1-jdk-8"
+- name: ${_MAVEN_IMAGE}
   id: run-store-scu
   volumes:
   - name: 'vol1'
@@ -89,7 +89,7 @@
   waitFor:
   - wait-for-adapter
 
-- name: "maven:3.6.1-jdk-8"
+- name: ${_MAVEN_IMAGE}
   id: run-find-scu
   volumes:
   - name: 'vol1'
@@ -106,7 +106,7 @@
 
 # Stgcmtscu  waits for n-event-report after n-action request returns success,
 # if it doesn't get one within cloud build step timeout of 30 seconds, step fails.
-- name: "maven:3.6.1-jdk-8"
+- name: ${_MAVEN_IMAGE}
   id: run-commitment-scu
   volumes:
   - name: 'vol1'
@@ -122,7 +122,7 @@
   - run-find-scu
   timeout: 30s
 
-- name: "maven:3.6.1-jdk-8"
+- name: ${_MAVEN_IMAGE}
   id: run-move-scu
   volumes:
   - name: 'vol1'
@@ -197,7 +197,7 @@
   waitFor:
   - run-move-scu
 
-- name: "maven:3.6.1-jdk-8"
+- name: ${_MAVEN_IMAGE}
   id: check-commitment-diff
   volumes:
   - name: 'vol1'
@@ -244,3 +244,5 @@ substitutions:
   _ADAPTER_RUN_STEP: 'step_4'
   _STORE_SCP_RUN_STEP: 'step_3'
   _COMMITMENT_SCU_STEP: 'step_10'
+  _GRADLE_IMAGE: 'gradle:5.6-jdk11'
+  _MAVEN_IMAGE: 'maven:3.6-jdk-11'

--- a/util/build.gradle
+++ b/util/build.gradle
@@ -20,7 +20,7 @@ plugins {
 
 buildDir = '/tmp/gradle_build/dicom_adapter/util'
 
-sourceCompatibility = 1.8
+sourceCompatibility = 1.11
 version = '0.0.1'
 
 compileJava {

--- a/util/src/main/java/com/google/cloud/healthcare/imaging/dicomadapter/GcpMetadataUtil.java
+++ b/util/src/main/java/com/google/cloud/healthcare/imaging/dicomadapter/GcpMetadataUtil.java
@@ -22,6 +22,7 @@ import com.google.api.client.http.HttpStatusCodes;
 import com.google.common.io.CharStreams;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,9 +33,8 @@ public class GcpMetadataUtil {
   private static Logger log = LoggerFactory.getLogger(GcpMetadataUtil.class);
 
   /**
-   * Retrieves metadata element specified by path in GCE environment
-   * https://cloud.google.com/compute/docs/storing-retrieving-metadata
-   * @param requestFactory
+   * Retrieves metadata element specified by path in GCE environment https://cloud.google.com/compute/docs/storing-retrieving-metadata
+   *
    * @param path metadata path
    */
   public static String get(HttpRequestFactory requestFactory, String path) {
@@ -53,6 +53,9 @@ public class GcpMetadataUtil {
 
       return CharStreams.toString(new InputStreamReader(
           httpResponse.getContent(), StandardCharsets.UTF_8));
+    } catch (UnknownHostException e) {
+      log.trace("Not GCP environment, failed to get metadata for {} with exception {}", path, e);
+      return null;
     } catch (IOException | IllegalArgumentException e) {
       log.warn("Failed to get metadata for {} with exception {}", path, e);
       return null;


### PR DESCRIPTION
- Deprecate peer_dicomweb_addr peer_dicomweb_stow_path
- Jetty client http2 implementation of stow-rs used by c-store service and export adapter. Main difference - it can receive (error) response while transmitting data stream.
- updated to java 11. Initially because I tried to use native new java http client. Later left as is, since there seem to be no drawbacks.

Baked both pull requests into one because export adapter got broken pipe errors while trying to use old stowrs implementation (exactly same as #5), but when I tried to replace client with Jetty to actually see the error, it just worked. Doubt it's worth looking in too deeply, since that's what I was going to do next anyway.

Note: Jetty client implements only stow-rs (POST with binary data). I don't see particularly good reason to over-complicate GET requests with use of low level api.