### PR TITLE
[#68] Fix warnings during dockerBuildImage step

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,7 @@ spec:
             - containerPort: 2575
               protocol: TCP
               name: "port"
-          command:
-            - "/import/bin/import"
+          args:
             - "--dimse_aet=IMPORTADAPTER"
             - "--dimse_port=2575"
             - "--dicomweb_address=https://healthcare.googleapis.com/v1beta1/projects/myproject/locations/us-central1/datasets/mydataset/dicomStores/mydicomstore/dicomWeb"
@@ -184,8 +183,7 @@ containers in `dicom_adapter.yaml`. Modify the flags for your use case.
 ```yaml
         - name: dicom-export-adapter
           image: gcr.io/cloud-healthcare-containers/healthcare-api-dicom-dicomweb-adapter-export:0.1.1
-          command:
-            - "/export/bin/export"
+          args:
             - "--peer_dimse_aet=PEERAET"
             - "--peer_dimse_ip=localhost"
             - "--peer_dimse_port=104"

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ spec:
     spec:
       containers:
         - name: dicom-import-adapter
-          image: gcr.io/cloud-healthcare-containers/healthcare-api-dicom-dicomweb-adapter-import:0.1.14
+          image: gcr.io/cloud-healthcare-containers/healthcare-api-dicom-dicomweb-adapter-import:0.2.0
           ports:
             - containerPort: 2575
               protocol: TCP
@@ -182,7 +182,7 @@ containers in `dicom_adapter.yaml`. Modify the flags for your use case.
 
 ```yaml
         - name: dicom-export-adapter
-          image: gcr.io/cloud-healthcare-containers/healthcare-api-dicom-dicomweb-adapter-export:0.1.1
+          image: gcr.io/cloud-healthcare-containers/healthcare-api-dicom-dicomweb-adapter-export:0.2.0
           args:
             - "--peer_dimse_aet=PEERAET"
             - "--peer_dimse_ip=localhost"

--- a/dicom_util/src/main/java/com/google/cloud/healthcare/LogUtil.java
+++ b/dicom_util/src/main/java/com/google/cloud/healthcare/LogUtil.java
@@ -26,9 +26,9 @@ public class LogUtil {
 
   // Print all logs emitted by log4j (as low as DEBUG level) to stdout. This
   // is useful for seeing dcm4che errors in verbose mode.
-  public static void Log4jToStdout() {
+  public static void Log4jToStdout(String level) {
     Properties log4jProperties = new Properties();
-    log4jProperties.setProperty("log4j.rootLogger", "DEBUG, console");
+    log4jProperties.setProperty("log4j.rootLogger", level + ", console");
     log4jProperties.setProperty("log4j.appender.console", "org.apache.log4j.ConsoleAppender");
     log4jProperties.setProperty("log4j.appender.console.layout", "org.apache.log4j.PatternLayout");
     log4jProperties.setProperty(

--- a/export/build.gradle
+++ b/export/build.gradle
@@ -38,7 +38,7 @@ run {
 buildDir = '/tmp/gradle_build/dicom_adapter/export'
 
 sourceCompatibility = 1.11
-version = '0.1'
+version = '0.2'
 
 compileJava {
     // Print out detailed deprecation warnings.

--- a/export/build.gradle
+++ b/export/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.bmuschko:gradle-docker-plugin:3.2.2'
+        classpath 'com.bmuschko:gradle-docker-plugin:6.2.0'
     }
 }
 
@@ -72,7 +72,7 @@ apply plugin: 'com.bmuschko.docker-java-application'
 docker {
     javaApplication {
         baseImage = 'openjdk:11'
-        tag = project.findProperty("docker_tag") ?: "export_adapter"
+        images = [project.findProperty("docker_tag") ?: "export_adapter"]
     }
 }
 
@@ -115,9 +115,9 @@ task printVersion {
     }
 }
 
-dockerCopyDistResources.finalizedBy tasks.copySourceAndLicenseToDockerImage
-dockerDistTar {
-    instruction {'ADD license /usr/share/oss-license'}
-    instruction {'ADD source /usr/share/oss-source'}
+dockerSyncBuildContext.finalizedBy tasks.copySourceAndLicenseToDockerImage
+dockerCreateDockerfile {
+    instruction 'ADD license /usr/share/oss-license'
+    instruction 'ADD source /usr/share/oss-source'
 }
 

--- a/export/src/main/java/com/google/cloud/healthcare/imaging/dicomadapter/ExportAdapter.java
+++ b/export/src/main/java/com/google/cloud/healthcare/imaging/dicomadapter/ExportAdapter.java
@@ -51,9 +51,7 @@ public class ExportAdapter {
     jCommander.parse(args);
 
     // Adjust logging.
-    if (flags.verbose) {
-      LogUtil.Log4jToStdout();
-    }
+    LogUtil.Log4jToStdout(flags.verbose ? "DEBUG" : "ERROR");
 
     // DicomWeb client for source of DICOM.
     GoogleCredentials credentials = GoogleCredentials.getApplicationDefault();

--- a/import/build.gradle
+++ b/import/build.gradle
@@ -87,7 +87,7 @@ docker {
     javaApplication {
         baseImage = 'openjdk:11'
         images = [project.findProperty("docker_tag") ?: "import_adapter"]
-        applicationDefaultJvmArgs = transcoderJvmArgs
+        jvmArgs = transcoderJvmArgs
     }
 }
 

--- a/import/build.gradle
+++ b/import/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.bmuschko:gradle-docker-plugin:3.2.2'
+        classpath 'com.bmuschko:gradle-docker-plugin:6.2.0'
     }
 }
 
@@ -86,7 +86,7 @@ apply plugin: 'com.bmuschko.docker-java-application'
 docker {
     javaApplication {
         baseImage = 'openjdk:11'
-        tag = project.findProperty("docker_tag") ?: "import_adapter"
+        images = [project.findProperty("docker_tag") ?: "import_adapter"]
         applicationDefaultJvmArgs = transcoderJvmArgs
     }
 }
@@ -130,9 +130,9 @@ task printVersion {
     }
 }
 
-dockerCopyDistResources.finalizedBy tasks.copySourceAndLicenseToDockerImage
-dockerDistTar {
-    instruction {'ADD license /usr/share/oss-license'}
-    instruction {'ADD source /usr/share/oss-source'}
+dockerSyncBuildContext.finalizedBy tasks.copySourceAndLicenseToDockerImage
+dockerCreateDockerfile {
+    instruction 'ADD license /usr/share/oss-license'
+    instruction 'ADD source /usr/share/oss-source'
 }
 

--- a/import/build.gradle
+++ b/import/build.gradle
@@ -46,7 +46,7 @@ test {
 buildDir = '/tmp/gradle_build/dicom_adapter/import'
 
 sourceCompatibility = 1.11
-version = '0.1'
+version = '0.2'
 
 compileJava {
     // Print out detailed deprecation warnings.

--- a/import/src/main/java/com/google/cloud/healthcare/imaging/dicomadapter/ImportAdapter.java
+++ b/import/src/main/java/com/google/cloud/healthcare/imaging/dicomadapter/ImportAdapter.java
@@ -57,9 +57,7 @@ public class ImportAdapter {
     }
 
     // Adjust logging.
-    if (flags.verbose) {
-      LogUtil.Log4jToStdout();
-    }
+    LogUtil.Log4jToStdout(flags.verbose ? "DEBUG" : "ERROR");
 
     // Credentials, use the default service credentials.
     GoogleCredentials credentials = GoogleCredentials.getApplicationDefault();

--- a/import/src/test/java/com/google/cloud/healthcare/imaging/dicomadapter/CFindServiceTest.java
+++ b/import/src/test/java/com/google/cloud/healthcare/imaging/dicomadapter/CFindServiceTest.java
@@ -53,7 +53,7 @@ public final class CFindServiceTest {
 
   @Before
   public void setUp() throws Exception {
-    LogUtil.Log4jToStdout();
+    LogUtil.Log4jToStdout("DEBUG");
 
     Device device = new Device(clientAET);
     Connection conn = new Connection();

--- a/import/src/test/java/com/google/cloud/healthcare/imaging/dicomadapter/CMoveServiceTest.java
+++ b/import/src/test/java/com/google/cloud/healthcare/imaging/dicomadapter/CMoveServiceTest.java
@@ -58,7 +58,7 @@ public final class CMoveServiceTest {
 
   @Before
   public void setUp() throws Exception {
-    LogUtil.Log4jToStdout();
+    LogUtil.Log4jToStdout("DEBUG");
 
     // Create the C-STORE client.
     Device device = new Device(clientAET);

--- a/import/src/test/java/com/google/cloud/healthcare/imaging/dicomadapter/StorageCommitmentServiceTest.java
+++ b/import/src/test/java/com/google/cloud/healthcare/imaging/dicomadapter/StorageCommitmentServiceTest.java
@@ -65,7 +65,7 @@ public final class StorageCommitmentServiceTest {
 
   @Before
   public void setUp() throws Exception {
-    LogUtil.Log4jToStdout();
+    LogUtil.Log4jToStdout("DEBUG");
 
     // Create the C-STORE client.
     Device device = new Device(clientAET);

--- a/integration_test/cloudbuild-integration-test.yaml
+++ b/integration_test/cloudbuild-integration-test.yaml
@@ -42,7 +42,9 @@
   id: adapter-main
   entrypoint: 'bash'
   args: [ '-c',
-          "/import/bin/import \
+          "java -Dorg.dcm4che3.imageio.codec.ImageReaderFactory=com/google/cloud/healthcare/imaging/dicomadapter/transcoder/ImageReaderFactory.properties \
+                -Dorg.dcm4che3.imageio.codec.ImageWriterFactory=com/google/cloud/healthcare/imaging/dicomadapter/transcoder/ImageWriterFactory.properties \
+                -cp /app/resources:/app/classes:/app/libs/* com.google.cloud.healthcare.imaging.dicomadapter.ImportAdapter \
           --dimse_aet=IMPORTADAPTER \
           --dimse_port=${_ADAPTER_PORT} \
           --dicomweb_address=https://healthcare.googleapis.com/${_VERSION}/projects/${_PROJECT}/locations/${_LOCATION}/datasets/${_DATASET}/dicomStores/${_STORE_NAME}/dicomWeb \


### PR DESCRIPTION
Need to use args instead of command in yaml due to entrypoint change (or fully copy java command line like I do in integration test).

Old version of gradle-docker-plugin created a shell script at /import/bin/import to use as entrypoint, new version's entrypoint is just a simple java command.