### PR TITLE
[#70] Upgrade API requests from v1beta to v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ spec:
           args:
             - "--dimse_aet=IMPORTADAPTER"
             - "--dimse_port=2575"
-            - "--dicomweb_address=https://healthcare.googleapis.com/v1beta1/projects/myproject/locations/us-central1/datasets/mydataset/dicomStores/mydicomstore/dicomWeb"
+            - "--dicomweb_address=https://healthcare.googleapis.com/v1/projects/myproject/locations/us-central1/datasets/mydataset/dicomStores/mydicomstore/dicomWeb"
 ```
 
 **The yaml configuration has changed slightly from version 0.1 to 0.2. Please see the [upgrade guide](https://github.com/GoogleCloudPlatform/healthcare-dicom-dicomweb-adapter/wiki/DICOM-Adapter-Upgrade-Guide#to-version-020) for instructions on how to upgrade your configuration.**
@@ -191,7 +191,7 @@ containers in `dicom_adapter.yaml`. Modify the flags for your use case.
             - "--peer_dimse_port=104"
             - "--project_id=myproject"
             - "--subscription_id=mysub"
-            - "--dicomweb_addr=https://healthcare.googleapis.com/v1beta1"
+            - "--dicomweb_addr=https://healthcare.googleapis.com/v1"
             - "--oauth_scopes=https://www.googleapis.com/auth/pubsub"
 ```
 

--- a/integration_test/cloudbuild-integration-test.yaml
+++ b/integration_test/cloudbuild-integration-test.yaml
@@ -369,7 +369,7 @@
 
 timeout: 1800s
 substitutions:
-  _VERSION: v1beta1
+  _VERSION: v1
   _PROJECT: gcp-healthcare-oss-test
   _IMAGEPROJECT: cloud-healthcare-containers
   _LOCATION: us-central1
@@ -393,6 +393,6 @@ substitutions:
   _REPLACED_UID: '2.25.140302709094137852884202099990798014056'
   _GRADLE_IMAGE: 'gradle:5.6-jdk11'
   _MAVEN_IMAGE: 'maven:3.6-jdk-11'
-  _CLOUD_SDK_IMAGE: 'google/cloud-sdk:272.0.0'
+  _CLOUD_SDK_IMAGE: 'google/cloud-sdk:290.0.0'
   _PUBLISH: 'false'
 

--- a/samples/data-protection-toolkit-minimal.yaml
+++ b/samples/data-protection-toolkit-minimal.yaml
@@ -71,11 +71,10 @@ projects:
                     - containerPort: 2575
                       protocol: TCP
                       name: "port"
-                  command:
-                    - "/import/bin/import"
+                  args:
                     - "--dimse_aet=IMPORTADAPTER"
                     - "--dimse_port=2575"
-                    - "--dicomweb_address=https://healthcare.googleapis.com/v1beta1/projects/my-project/locations/us-central1-c/datasets/dataset/dicomStores/dicomStores/dicomWeb"
+                    - "--dicomweb_address=https://healthcare.googleapis.com/v1/projects/my-project/locations/us-central1-c/datasets/dataset/dicomStores/dicomStores/dicomWeb"
                     - "--aet_dictionary_inline=\"[{\"name\":\"STORESCP\",\"host\":host1,\"port\":2576},{\"name\":\"STGCMTSCU\",\"host\":host2,\"port\":4000},]\""
                     - "--verbose"
                   env:

--- a/samples/data-protection-toolkit-minimal.yaml
+++ b/samples/data-protection-toolkit-minimal.yaml
@@ -66,7 +66,7 @@ projects:
             spec:
               containers:
                 - name: dicom-import-adapter
-                  image: gcr.io/cloud-healthcare-containers/healthcare-api-dicom-dicomweb-adapter-import:0.1.1
+                  image: gcr.io/cloud-healthcare-containers/healthcare-api-dicom-dicomweb-adapter-import:0.2.1
                   ports:
                     - containerPort: 2575
                       protocol: TCP


### PR DESCRIPTION
Since api version isn't actually hard-coded anywhere, it's just matter of updating integration test and samples.

In latest gcloud sdk version (290.0.0), healthcare is still beta, so usage via gcloud didn't change.