### PR TITLE
Move error logging from DicomWebClientJetty to CStoreService

### DIFF
--- a/dicom_util/src/main/java/com/google/cloud/healthcare/DicomWebClientJetty.java
+++ b/dicom_util/src/main/java/com/google/cloud/healthcare/DicomWebClientJetty.java
@@ -140,16 +140,8 @@ public class DicomWebClientJetty implements IDicomWebClient {
 
       int httpStatus = responseCodeFuture.get();
       if (httpStatus != HttpStatus.OK_200) {
-        try {
-          JSONObject responseJson = new JSONObject(resultBuilder.toString());
-          log.error("STOW-RS response: " + responseJson.toString());
-          throw new DicomWebException("Http_" + httpStatus
-              + ", " + responseJson.getJSONObject("error").getString("status")
-              + ", " + responseJson.getJSONObject("error").getString("message"),
-              httpStatus, Status.ProcessingFailure);
-        } catch (JSONException e) {
-          throw new DicomWebException("Http_" + httpStatus, httpStatus, Status.ProcessingFailure);
-        }
+        String resp = resultBuilder.toString();
+        throw new DicomWebException("Http_" + httpStatus + ": " + resp, httpStatus, Status.ProcessingFailure);
       }
     } catch (Exception e) {
       if (e instanceof DicomWebException) {

--- a/import/src/main/java/com/google/cloud/healthcare/imaging/dicomadapter/CStoreService.java
+++ b/import/src/main/java/com/google/cloud/healthcare/imaging/dicomadapter/CStoreService.java
@@ -136,17 +136,22 @@ public class CStoreService extends BasicCStoreSCP {
       response.setInt(Tag.Status, VR.US, Status.Success);
       MonitoringService.addEvent(Event.CSTORE_BYTES, countingStream.getCount());
     } catch (DicomWebException e) {
-      MonitoringService.addEvent(Event.CSTORE_ERROR);
+      reportError(e);
       DicomServiceException serviceException = new DicomServiceException(e.getStatus(), e);
       serviceException.setErrorComment(e.getMessage());
       throw serviceException;
     } catch (DicomServiceException e) {
-      MonitoringService.addEvent(Event.CSTORE_ERROR);
+      reportError(e);
       throw e;
     } catch (Throwable e) {
-      MonitoringService.addEvent(Event.CSTORE_ERROR);
+      reportError(e);
       throw new DicomServiceException(Status.ProcessingFailure, e);
     }
+  }
+
+  private void reportError(Throwable e) {
+    MonitoringService.addEvent(Event.CSTORE_ERROR);
+    log.error("C-STORE request failed: ", e);
   }
 
   private void validateParam(String value, String name) throws DicomServiceException {


### PR DESCRIPTION
Now we'll get error logs for any failed C-STORE requests.