### PR TITLE
Default to HTTP 2.0 for StoreInstances requests

### DIFF
--- a/import/src/main/java/com/google/cloud/healthcare/imaging/dicomadapter/Flags.java
+++ b/import/src/main/java/com/google/cloud/healthcare/imaging/dicomadapter/Flags.java
@@ -63,9 +63,9 @@ public class Flags {
 
   @Parameter(
       names = {"--stow_http2"},
-      description = "Whether to use HTTP 2.0 for StowRS (i.e. StoreInstances) requests. False by default."
+      description = "Whether to use HTTP 2.0 for StowRS (i.e. StoreInstances) requests. True by default."
   )
-  Boolean useHttp2ForStow = false;
+  Boolean useHttp2ForStow = true;
 
   @Parameter(
       names = {"--oauth_scopes"},


### PR DESCRIPTION
Manually tested that flakiness no longer exists when using HTTP 2.0.