### PR TITLE
Increase HTTP2 session establishment timeout

### DIFF
--- a/dicom_util/src/main/java/com/google/cloud/healthcare/DicomWebClientJetty.java
+++ b/dicom_util/src/main/java/com/google/cloud/healthcare/DicomWebClientJetty.java
@@ -74,7 +74,11 @@ public class DicomWebClientJetty implements IDicomWebClient {
       FuturePromise<Session> sessionPromise = new FuturePromise<>();
       client.connect(sslContextFactory, new InetSocketAddress(uri.getHost(), CONNECT_PORT),
           new ServerSessionListener.Adapter(), sessionPromise);
-      Session session = sessionPromise.get(600, TimeUnit.SECONDS);
+      // Having a low timeout here causes flakyness when used with in transit compression.
+      // This is likely due to the Stow thread sleeping and then waking up again between
+      // the connect call and the session promise.get() call.
+      // Reference: https://github.com/GoogleCloudPlatform/healthcare-dicom-dicomweb-adapter/issues/108
+      Session session = sessionPromise.get(300, TimeUnit.SECONDS);
 
       // Prepare the request
       HttpFields requestFields = new HttpFields();

--- a/dicom_util/src/main/java/com/google/cloud/healthcare/DicomWebClientJetty.java
+++ b/dicom_util/src/main/java/com/google/cloud/healthcare/DicomWebClientJetty.java
@@ -74,7 +74,7 @@ public class DicomWebClientJetty implements IDicomWebClient {
       FuturePromise<Session> sessionPromise = new FuturePromise<>();
       client.connect(sslContextFactory, new InetSocketAddress(uri.getHost(), CONNECT_PORT),
           new ServerSessionListener.Adapter(), sessionPromise);
-      Session session = sessionPromise.get(5, TimeUnit.SECONDS);
+      Session session = sessionPromise.get(600, TimeUnit.SECONDS);
 
       // Prepare the request
       HttpFields requestFields = new HttpFields();


### PR DESCRIPTION
Increase the timeout on DicomWebClientJetty to 10 min from 5 seconds

Proof that the exception occurs here:

ERROR com.google.cloud.healthcare.imaging.dicomadapter.CStoreService  - C-STORE request failed: 
com.google.cloud.healthcare.IDicomWebClient$DicomWebException: java.util.concurrent.TimeoutException
	at com.google.cloud.healthcare.DicomWebClientJetty.stowRs(DicomWebClientJetty.java:150)
	at com.google.cloud.healthcare.imaging.dicomadapter.CStoreService.lambda$store$3(CStoreService.java:150)
	at com.google.cloud.healthcare.imaging.dicomadapter.CStoreService$StreamCallable.call(CStoreService.java:289)
	at com.google.cloud.healthcare.imaging.dicomadapter.CStoreService$StreamCallable.call(CStoreService.java:273)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.util.concurrent.TimeoutException
	at org.eclipse.jetty.util.FuturePromise.get(FuturePromise.java:131)
	at com.google.cloud.healthcare.DicomWebClientJetty.stowRs(DicomWebClientJetty.java:77)


I don't know why it would take us more than 5 seconds to connect to the stow endpoint. My theory is that this thread, when running in the executor service: https://github.com/GoogleCloudPlatform/healthcare-dicom-dicomweb-adapter/blob/79e204c6ec187b1bd5222ae99814f6ce0fe07267/import/src/main/java/com/google/cloud/healthcare/imaging/dicomadapter/CStoreService.java#L198 goes to sleep while the other threads (for redaction and compression) are running. The thread then resumes from its sleep and times out while we were waiting for the other threads to complete.

In the logs where this error comes up, we do see compression / decompression progress being made, which supports this theory.

Since there is no reason why the timeout needs to exist at all here, increasing it to 10 minutes seems fine to me.