### PR TITLE
Rework DICOM Adapter Integration so that server AET can be specified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 /terraform_alert_config/import_adapter/.terraform
 /terraform_alert_config/import_adapter/.terraform.tfstate
 /terraform_alert_config/import_adapter/.terraform.tfstate.backup
+
+bin
+aets.json

--- a/README.md
+++ b/README.md
@@ -30,6 +30,34 @@ The Import Adapter converts incoming DIMSE requests to corresponding DICOMWeb re
 WADO-RS request to fetch the instance and a C-STORE request to transfer it to the C-MOVE destination
 - Storage commitment service to QIDO-RS
 
+The following configuration needs to be added to the dicom-adapter.yaml file to use C-STORE. 
+Please see the [Deployment using Kubernetes](#deployment-using-kubernetes) section for more information.
+```yaml
+env:
+- name: ENV_AETS_DICOM_JSON
+  valueFrom:
+    configMapKeyRef:
+      name: aet_dicom_map
+      key: AETs.json
+```
+
+Here is an example JSON dictionary:
+```shell
+[
+	{
+		"name": "AET1", 
+		"dicom": "HEALTHcARE_DICOM_PATH", 
+		"port": 11113
+	},
+	{
+		"name": "AET2", 
+		"dicom": "HEALTHcARE_DICOM_PATH", 
+		"port": 11114
+	},
+	...
+]
+```
+
 Note that any C-FIND query on the ModalitiesInStudy tag will result in 1 QIDO-RS query per modality.
 
 Available AET destinations for the C-MOVE and storage commitment services are configured via an AET dictionary json file, 

--- a/import/src/main/java/com/google/cloud/healthcare/imaging/dicomadapter/Flags.java
+++ b/import/src/main/java/com/google/cloud/healthcare/imaging/dicomadapter/Flags.java
@@ -90,6 +90,19 @@ public class Flags {
   boolean verbose = false;
 
   @Parameter(
+      names = {"--aet_dicom_map"},
+      description =
+          "Path to json containing aet dicom definitions (array containing name/dicom/port per element)")
+  String aetDicomMapPath = "";
+
+  @Parameter(
+      names = {"--aet_dicom_map_inline"},
+      description = "Json array containing aet dicom definitions (name/dicom/port per element). "
+          + "Only one of aet_dicom_map and aet_dicom_map_inline needs to be specified."
+  )
+  String aetDicomMapInline;
+
+  @Parameter(
       names = {"--aet_dictionary"},
       description =
           "Path to json containing aet definitions (array containing name/host/port per element)")

--- a/util/src/main/java/com/google/cloud/healthcare/imaging/dicomadapter/AetDICOMMap.java
+++ b/util/src/main/java/com/google/cloud/healthcare/imaging/dicomadapter/AetDICOMMap.java
@@ -1,0 +1,112 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.healthcare.imaging.dicomadapter;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AetDICOMMap {
+
+  private static final String ENV_AETS_JSON = "ENV_AETS_DICOM_JSON";
+  private static Logger log = LoggerFactory.getLogger(AetDICOMMap.class);
+  private List<Aet> aetMap = new ArrayList<Aet>();
+
+  /**
+   * Creates AetDICOMMap based on provided path to json or environment variable
+   * if both parameters absent, will try ENV_AETS_JSON
+   * 
+   * @param jsonInline checked 1st
+   * @param jsonPath   checked 2nd
+   */
+  public AetDICOMMap(String jsonInline, String jsonPath) throws IOException {
+    JSONArray jsonArray = JsonUtil.parseConfig(jsonInline, jsonPath, ENV_AETS_JSON);
+
+    if (jsonArray != null) {
+      for (Object elem : jsonArray) {
+        JSONObject elemJson = (JSONObject) elem;
+        String name = elemJson.getString("name");
+        aetMap.add(new Aet(name, elemJson.getString("dicom"), elemJson.getInt("port")));
+      }
+    }
+
+    log.info("aetMap = {}", aetMap);
+  }
+
+  public AetDICOMMap(Aet[] aets) {
+    for (Aet elem : aets) {
+      aetMap.add(elem);
+    }
+  }
+
+  public List<Aet> getAets() {
+    return this.aetMap;
+  }
+
+  public static class Aet {
+
+    private String name;
+    private String dicom;
+    private int port;
+
+    public Aet(String name, String dicom, int port) {
+      this.name = name;
+      this.dicom = dicom;
+      this.port = port;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public String getDicom() {
+      return dicom;
+    }
+
+    public void setDicom(String dicom) {
+      this.dicom = dicom;
+    }
+
+    public int getPort() {
+      return port;
+    }
+
+    public void setPort(int port) {
+      this.port = port;
+    }
+
+    @Override
+    public String toString() {
+      return "Aet{" +
+          "name='" + name + '\'' +
+          ", dicom='" + dicom + '\'' +
+          ", port=" + port +
+          "}";
+    }
+  }
+}


### PR DESCRIPTION
This PR resolves issue [#698](https://github.com/BioticsAI/bioticsreports/issues/698) where I replaced the `--dimse_aet`, `--dimse_port` and `--dicomweb_address` flags with `--aet_dicom_map` flag which points to the  `aet.json` dictionary file

Usage
-----------

to run the java code
```bash
gradle build
gradle run -Dexec.args="--aet_dicom_map=./aets.json"
```

Note that gradle version should be less than 7.0

aets.json example

```shell
[
	{
		"name": "AET1", 
		"dicom": "HEALTHcARE_DICOM_PATH", 
		"port": 11113
	},
	{
		"name": "AET2", 
		"dicom": "HEALTHcARE_DICOM_PATH", 
		"port": 11114
	},
	...
]
```

to test the code you can run this command

```shell
storescu 0.0.0.0 4009 ../image-00010.dcm --propose-j2k-lossy -aec IMPORTADAPTER --debug
```

to install storescu tool use this url https://dicom.offis.de/dcmtk.php.en