### PR TITLE
Switch to Cloud BOM in Gradle Build

### DIFF
--- a/dicom_util/build.gradle
+++ b/dicom_util/build.gradle
@@ -33,9 +33,12 @@ repositories {
 }
 
 dependencies {
-    compile "org.json:json:20170516"
+    compile platform('com.google.cloud:libraries-bom:5.1.0')
+    compile platform('com.google.cloud:google-cloud-shared-dependencies:0.1.0')
+    compile "com.google.api-client:google-api-client"
     compile "com.google.inject:guice:4.1.0"
-    compile "com.google.api-client:google-api-client:1.30.5"
+
+    compile "org.json:json:20170516"
     compile "junit:junit:4.12"
     compile "org.junit.jupiter:junit-jupiter-engine:5.0.0"
     compile "org.dcm4che:dcm4che-core:5.31.2"

--- a/export/build.gradle
+++ b/export/build.gradle
@@ -52,11 +52,14 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.cloud:google-cloud-pubsub:1.98.0'
+    compile platform('com.google.cloud:libraries-bom:5.1.0')
+    compile platform('com.google.cloud:google-cloud-shared-dependencies:0.1.0')
+    compile 'com.google.cloud:google-cloud-pubsub'
     compile 'com.google.guava:guava:28.1-jre'
+    compile 'com.google.auth:google-auth-library-oauth2-http'
+    compile "com.google.api-client:google-api-client"
+
     compile "com.beust:jcommander:1.72"
-    compile 'com.google.auth:google-auth-library-oauth2-http:0.17.2'
-    compile "com.google.api-client:google-api-client:1.30.5"
     compile "org.dcm4che:dcm4che-core:5.31.2"
     compile "org.dcm4che:dcm4che-net:5.31.2"
     compile project(":dicom_util")

--- a/import/build.gradle
+++ b/import/build.gradle
@@ -60,10 +60,13 @@ repositories {
 }
 
 dependencies {
+    compile platform('com.google.cloud:libraries-bom:5.1.0')
+    compile platform('com.google.cloud:google-cloud-shared-dependencies:0.1.0')
     compile 'com.google.guava:guava:28.1-jre'
+    compile 'com.google.auth:google-auth-library-oauth2-http'
+    compile "com.google.api-client:google-api-client"
+  
     compile "com.beust:jcommander:1.72"
-    compile 'com.google.auth:google-auth-library-oauth2-http:0.17.2'
-    compile "com.google.api-client:google-api-client:1.30.5"
     compile "org.dcm4che:dcm4che-core:5.31.2"
     compile "org.dcm4che:dcm4che-net:5.31.2"
 

--- a/util/build.gradle
+++ b/util/build.gradle
@@ -37,7 +37,9 @@ dependencies {
     compile "org.dcm4che:dcm4che-core:5.31.2"
     compile "org.dcm4che:dcm4che-net:5.31.2"
     compile "org.json:json:20180813"
-    compile "com.google.cloud:google-cloud-monitoring:1.98.0"
+    compile platform('com.google.cloud:libraries-bom:5.1.0')
+    compile platform('com.google.cloud:google-cloud-shared-dependencies:0.1.0')
+    compile "com.google.cloud:google-cloud-monitoring"
 
     testCompile "com.google.truth:truth:1.0"
     testCompile "junit:junit:4.2"


### PR DESCRIPTION
This PR switches our Gradle configuration to depend on `com.google.cloud:libraries-bom` and `com.google.cloud:google-cloud-shared-dependencies`. This Bill of Materials (BOM) provides the versions for the cloud libraries we use, hence we do not need to coordinate among the versions themselves.

I tried to match the version of the BOM roughly with the current version being used. In the future, the goal is to upgrade all the Cloud dependencies together