### PR TITLE
 trigger rebuild to patch libpng CVE-2026-22801

### DIFF
--- a/import/build.gradle
+++ b/import/build.gradle
@@ -145,3 +145,5 @@ dockerCreateDockerfile {
     instruction 'ADD source /usr/share/oss-source'
 }
 
+
+// Security Update: Trigger rebuild for CVE-2026-22801


### PR DESCRIPTION
### Description
This change triggers a rebuild of the import adapter Docker image to pick up the latest security patches from the base image (`eclipse-temurin:11-jammy`).

**Reason for Change:**
* **Vulnerability:** Addresses `CVE-2026-22801` (libpng heap buffer over-read).
* **Fix:** The base image tag `eclipse-temurin:11-jammy` has been updated upstream to include the patched version of `libpng` (e.g., `1.6.37-3ubuntu0.3`). A fresh build will pull these updated layers and resolve the security alert.
* **Bug:** b/476709611

