### PR TITLE
rebuild: Force rebuild of import and export adapters to patch OS vulnerabilities

### DIFF
--- a/export/build.gradle
+++ b/export/build.gradle
@@ -124,3 +124,5 @@ dockerCreateDockerfile {
     instruction 'ADD source /usr/share/oss-source'
 }
 
+
+// Security Update: Trigger rebuild for CVE-2026-33636, CVE-2026-27135, CVE-2026-33416

--- a/import/build.gradle
+++ b/import/build.gradle
@@ -147,3 +147,5 @@ dockerCreateDockerfile {
 
 
 // Security Update: Trigger rebuild for CVE-2026-22801
+
+// Security Update: Trigger rebuild for CVE-2026-33636, CVE-2026-27135, CVE-2026-33416


### PR DESCRIPTION
This is a placeholder change to force a rebuild of both the DICOM Import and Export adapter container images.
Rebuilding the images will pull the latest base layers (eclipse-temurin:11-jammy) which contain security patches for the following OS-level vulnerabilities:
- CVE-2026-33636 (libpng)
- CVE-2026-33416 (libpng)
- CVE-2026-27135 (nghttp2)
This will resolve the outstanding public image scanning vulnerability findings.